### PR TITLE
Updated menu base styles to allow the widget control overlay

### DIFF
--- a/build.html
+++ b/build.html
@@ -8,7 +8,10 @@
   <span class="nav-right" data-fl-toggle-menu=".fl-menu">
         <div class="hamburger hamburger--slider">
           <span class="hamburger-box">
-            <span class="hamburger-inner"></span>
+            <span class="hamburger-inner">
+              <span class="hamburger-inner-1"></span>
+              <span class="hamburger-inner-2"></span>
+            </span>
           </span>
         </div>
       </span> {{/if}}
@@ -27,7 +30,10 @@
   <span class="nav-right" data-fl-toggle-menu=".fl-menu">
         <div class="hamburger hamburger--slider">
           <span class="hamburger-box">
-            <span class="hamburger-inner"></span>
+            <span class="hamburger-inner">
+              <span class="hamburger-inner-1"></span>
+              <span class="hamburger-inner-2"></span>
+            </span>
           </span>
         </div>
       </span> {{/if}} {{/if}}

--- a/css/hamburgers.css
+++ b/css/hamburgers.css
@@ -32,7 +32,7 @@
   display: block;
   top: 50%;
   margin-top: -2px; }
-  .hamburger-inner, .hamburger-inner::before, .hamburger-inner::after {
+  .hamburger-inner, .hamburger-inner-1, .hamburger-inner-2 {
     width: 40px;
     height: 4px;
     background-color: #000;
@@ -41,12 +41,12 @@
     transition-property: transform;
     transition-duration: 0.15s;
     transition-timing-function: ease; }
-  .hamburger-inner::before, .hamburger-inner::after {
+  .hamburger-inner-1, .hamburger-inner-2 {
     content: "";
     display: block; }
-  .hamburger-inner::before {
+  .hamburger-inner-1 {
     top: -10px; }
-  .hamburger-inner::after {
+  .hamburger-inner-2 {
     bottom: -10px; }
 
 /*
@@ -57,15 +57,15 @@
 
 .hamburger--3dx .hamburger-inner {
   transition: transform 0.15s cubic-bezier(0.645, 0.045, 0.355, 1), background-color 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1); }
-  .hamburger--3dx .hamburger-inner::before, .hamburger--3dx .hamburger-inner::after {
+  .hamburger--3dx .hamburger-inner-1, .hamburger--3dx .hamburger-inner-2 {
     transition: transform 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1); }
 
 .hamburger--3dx.is-active .hamburger-inner {
   background-color: transparent;
   transform: rotateY(180deg); }
-  .hamburger--3dx.is-active .hamburger-inner::before {
+  .hamburger--3dx.is-active .hamburger-inner-1 {
     transform: translate3d(0, 10px, 0) rotate(45deg); }
-  .hamburger--3dx.is-active .hamburger-inner::after {
+  .hamburger--3dx.is-active .hamburger-inner-2 {
     transform: translate3d(0, -10px, 0) rotate(-45deg); }
 
 /*
@@ -76,15 +76,15 @@
 
 .hamburger--3dx-r .hamburger-inner {
   transition: transform 0.15s cubic-bezier(0.645, 0.045, 0.355, 1), background-color 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1); }
-  .hamburger--3dx-r .hamburger-inner::before, .hamburger--3dx-r .hamburger-inner::after {
+  .hamburger--3dx-r .hamburger-inner-1, .hamburger--3dx-r .hamburger-inner-2 {
     transition: transform 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1); }
 
 .hamburger--3dx-r.is-active .hamburger-inner {
   background-color: transparent;
   transform: rotateY(-180deg); }
-  .hamburger--3dx-r.is-active .hamburger-inner::before {
+  .hamburger--3dx-r.is-active .hamburger-inner-1 {
     transform: translate3d(0, 10px, 0) rotate(45deg); }
-  .hamburger--3dx-r.is-active .hamburger-inner::after {
+  .hamburger--3dx-r.is-active .hamburger-inner-2 {
     transform: translate3d(0, -10px, 0) rotate(-45deg); }
 
 /*
@@ -95,15 +95,15 @@
 
 .hamburger--3dy .hamburger-inner {
   transition: transform 0.15s cubic-bezier(0.645, 0.045, 0.355, 1), background-color 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1); }
-  .hamburger--3dy .hamburger-inner::before, .hamburger--3dy .hamburger-inner::after {
+  .hamburger--3dy .hamburger-inner-1, .hamburger--3dy .hamburger-inner-2 {
     transition: transform 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1); }
 
 .hamburger--3dy.is-active .hamburger-inner {
   background-color: transparent;
   transform: rotateX(-180deg); }
-  .hamburger--3dy.is-active .hamburger-inner::before {
+  .hamburger--3dy.is-active .hamburger-inner-1 {
     transform: translate3d(0, 10px, 0) rotate(45deg); }
-  .hamburger--3dy.is-active .hamburger-inner::after {
+  .hamburger--3dy.is-active .hamburger-inner-2 {
     transform: translate3d(0, -10px, 0) rotate(-45deg); }
 
 /*
@@ -114,15 +114,15 @@
 
 .hamburger--3dy-r .hamburger-inner {
   transition: transform 0.15s cubic-bezier(0.645, 0.045, 0.355, 1), background-color 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1); }
-  .hamburger--3dy-r .hamburger-inner::before, .hamburger--3dy-r .hamburger-inner::after {
+  .hamburger--3dy-r .hamburger-inner-1, .hamburger--3dy-r .hamburger-inner-2 {
     transition: transform 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1); }
 
 .hamburger--3dy-r.is-active .hamburger-inner {
   background-color: transparent;
   transform: rotateX(180deg); }
-  .hamburger--3dy-r.is-active .hamburger-inner::before {
+  .hamburger--3dy-r.is-active .hamburger-inner-1 {
     transform: translate3d(0, 10px, 0) rotate(45deg); }
-  .hamburger--3dy-r.is-active .hamburger-inner::after {
+  .hamburger--3dy-r.is-active .hamburger-inner-2 {
     transform: translate3d(0, -10px, 0) rotate(-45deg); }
 
 /*
@@ -133,15 +133,15 @@
 
 .hamburger--3dxy .hamburger-inner {
   transition: transform 0.15s cubic-bezier(0.645, 0.045, 0.355, 1), background-color 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1); }
-  .hamburger--3dxy .hamburger-inner::before, .hamburger--3dxy .hamburger-inner::after {
+  .hamburger--3dxy .hamburger-inner-1, .hamburger--3dxy .hamburger-inner-2 {
     transition: transform 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1); }
 
 .hamburger--3dxy.is-active .hamburger-inner {
   background-color: transparent;
   transform: rotateX(180deg) rotateY(180deg); }
-  .hamburger--3dxy.is-active .hamburger-inner::before {
+  .hamburger--3dxy.is-active .hamburger-inner-1 {
     transform: translate3d(0, 10px, 0) rotate(45deg); }
-  .hamburger--3dxy.is-active .hamburger-inner::after {
+  .hamburger--3dxy.is-active .hamburger-inner-2 {
     transform: translate3d(0, -10px, 0) rotate(-45deg); }
 
 /*
@@ -152,50 +152,50 @@
 
 .hamburger--3dxy-r .hamburger-inner {
   transition: transform 0.15s cubic-bezier(0.645, 0.045, 0.355, 1), background-color 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1); }
-  .hamburger--3dxy-r .hamburger-inner::before, .hamburger--3dxy-r .hamburger-inner::after {
+  .hamburger--3dxy-r .hamburger-inner-1, .hamburger--3dxy-r .hamburger-inner-2 {
     transition: transform 0s 0.1s cubic-bezier(0.645, 0.045, 0.355, 1); }
 
 .hamburger--3dxy-r.is-active .hamburger-inner {
   background-color: transparent;
   transform: rotateX(180deg) rotateY(180deg) rotateZ(-180deg); }
-  .hamburger--3dxy-r.is-active .hamburger-inner::before {
+  .hamburger--3dxy-r.is-active .hamburger-inner-1 {
     transform: translate3d(0, 10px, 0) rotate(45deg); }
-  .hamburger--3dxy-r.is-active .hamburger-inner::after {
+  .hamburger--3dxy-r.is-active .hamburger-inner-2 {
     transform: translate3d(0, -10px, 0) rotate(-45deg); }
 
 /*
    * Arrow
    */
-.hamburger--arrow.is-active .hamburger-inner::before {
+.hamburger--arrow.is-active .hamburger-inner-1 {
   transform: translate3d(-8px, 0, 0) rotate(-45deg) scale(0.7, 1); }
 
-.hamburger--arrow.is-active .hamburger-inner::after {
+.hamburger--arrow.is-active .hamburger-inner-2 {
   transform: translate3d(-8px, 0, 0) rotate(45deg) scale(0.7, 1); }
 
 /*
    * Arrow Right
    */
-.hamburger--arrow-r.is-active .hamburger-inner::before {
+.hamburger--arrow-r.is-active .hamburger-inner-1 {
   transform: translate3d(8px, 0, 0) rotate(45deg) scale(0.7, 1); }
 
-.hamburger--arrow-r.is-active .hamburger-inner::after {
+.hamburger--arrow-r.is-active .hamburger-inner-2 {
   transform: translate3d(8px, 0, 0) rotate(-45deg) scale(0.7, 1); }
 
 /*
    * Arrow Alt
    */
-.hamburger--arrowalt .hamburger-inner::before {
+.hamburger--arrowalt .hamburger-inner-1 {
   transition: top 0.1s 0.1s ease, transform 0.1s cubic-bezier(0.165, 0.84, 0.44, 1); }
 
-.hamburger--arrowalt .hamburger-inner::after {
+.hamburger--arrowalt .hamburger-inner-2 {
   transition: bottom 0.1s 0.1s ease, transform 0.1s cubic-bezier(0.165, 0.84, 0.44, 1); }
 
-.hamburger--arrowalt.is-active .hamburger-inner::before {
+.hamburger--arrowalt.is-active .hamburger-inner-1 {
   top: 0;
   transform: translate3d(-8px, -10px, 0) rotate(-45deg) scale(0.7, 1);
   transition: top 0.1s ease, transform 0.1s 0.1s cubic-bezier(0.895, 0.03, 0.685, 0.22); }
 
-.hamburger--arrowalt.is-active .hamburger-inner::after {
+.hamburger--arrowalt.is-active .hamburger-inner-2 {
   bottom: 0;
   transform: translate3d(-8px, 10px, 0) rotate(45deg) scale(0.7, 1);
   transition: bottom 0.1s ease, transform 0.1s 0.1s cubic-bezier(0.895, 0.03, 0.685, 0.22); }
@@ -203,18 +203,18 @@
 /*
    * Arrow Alt Right
    */
-.hamburger--arrowalt-r .hamburger-inner::before {
+.hamburger--arrowalt-r .hamburger-inner-1 {
   transition: top 0.1s 0.1s ease, transform 0.1s cubic-bezier(0.165, 0.84, 0.44, 1); }
 
-.hamburger--arrowalt-r .hamburger-inner::after {
+.hamburger--arrowalt-r .hamburger-inner-2 {
   transition: bottom 0.1s 0.1s ease, transform 0.1s cubic-bezier(0.165, 0.84, 0.44, 1); }
 
-.hamburger--arrowalt-r.is-active .hamburger-inner::before {
+.hamburger--arrowalt-r.is-active .hamburger-inner-1 {
   top: 0;
   transform: translate3d(8px, -10px, 0) rotate(45deg) scale(0.7, 1);
   transition: top 0.1s ease, transform 0.1s 0.1s cubic-bezier(0.895, 0.03, 0.685, 0.22); }
 
-.hamburger--arrowalt-r.is-active .hamburger-inner::after {
+.hamburger--arrowalt-r.is-active .hamburger-inner-2 {
   bottom: 0;
   transform: translate3d(8px, 10px, 0) rotate(-45deg) scale(0.7, 1);
   transition: bottom 0.1s ease, transform 0.1s 0.1s cubic-bezier(0.895, 0.03, 0.685, 0.22); }
@@ -224,9 +224,9 @@
  */
 .hamburger--arrowturn.is-active .hamburger-inner {
   transform: rotate(-180deg); }
-  .hamburger--arrowturn.is-active .hamburger-inner::before {
+  .hamburger--arrowturn.is-active .hamburger-inner-1 {
     transform: translate3d(8px, 0, 0) rotate(45deg) scale(0.7, 1); }
-  .hamburger--arrowturn.is-active .hamburger-inner::after {
+  .hamburger--arrowturn.is-active .hamburger-inner-2 {
     transform: translate3d(8px, 0, 0) rotate(-45deg) scale(0.7, 1); }
 
 /*
@@ -234,23 +234,23 @@
  */
 .hamburger--arrowturn-r.is-active .hamburger-inner {
   transform: rotate(-180deg); }
-  .hamburger--arrowturn-r.is-active .hamburger-inner::before {
+  .hamburger--arrowturn-r.is-active .hamburger-inner-1 {
     transform: translate3d(-8px, 0, 0) rotate(-45deg) scale(0.7, 1); }
-  .hamburger--arrowturn-r.is-active .hamburger-inner::after {
+  .hamburger--arrowturn-r.is-active .hamburger-inner-2 {
     transform: translate3d(-8px, 0, 0) rotate(45deg) scale(0.7, 1); }
 
 /*
    * Boring
    */
-.hamburger--boring .hamburger-inner, .hamburger--boring .hamburger-inner::before, .hamburger--boring .hamburger-inner::after {
+.hamburger--boring .hamburger-inner, .hamburger--boring .hamburger-inner-1, .hamburger--boring .hamburger-inner-2 {
   transition-property: none; }
 
 .hamburger--boring.is-active .hamburger-inner {
   transform: rotate(45deg); }
-  .hamburger--boring.is-active .hamburger-inner::before {
+  .hamburger--boring.is-active .hamburger-inner-1 {
     top: 0;
     opacity: 0; }
-  .hamburger--boring.is-active .hamburger-inner::after {
+  .hamburger--boring.is-active .hamburger-inner-2 {
     bottom: 0;
     transform: rotate(-90deg); }
 
@@ -263,21 +263,21 @@
   transition-duration: 0.13s;
   transition-delay: 0.13s;
   transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19); }
-  .hamburger--collapse .hamburger-inner::after {
+  .hamburger--collapse .hamburger-inner-2 {
     top: -20px;
     transition: top 0.2s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1), opacity 0.1s linear; }
-  .hamburger--collapse .hamburger-inner::before {
+  .hamburger--collapse .hamburger-inner-1 {
     transition: top 0.12s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1), transform 0.13s cubic-bezier(0.55, 0.055, 0.675, 0.19); }
 
 .hamburger--collapse.is-active .hamburger-inner {
   transform: translate3d(0, -10px, 0) rotate(-45deg);
   transition-delay: 0.22s;
   transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1); }
-  .hamburger--collapse.is-active .hamburger-inner::after {
+  .hamburger--collapse.is-active .hamburger-inner-2 {
     top: 0;
     opacity: 0;
     transition: top 0.2s cubic-bezier(0.33333, 0, 0.66667, 0.33333), opacity 0.1s 0.22s linear; }
-  .hamburger--collapse.is-active .hamburger-inner::before {
+  .hamburger--collapse.is-active .hamburger-inner-1 {
     top: 0;
     transform: rotate(-90deg);
     transition: top 0.1s 0.16s cubic-bezier(0.33333, 0, 0.66667, 0.33333), transform 0.13s 0.25s cubic-bezier(0.215, 0.61, 0.355, 1); }
@@ -291,21 +291,21 @@
   transition-duration: 0.13s;
   transition-delay: 0.13s;
   transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19); }
-  .hamburger--collapse-r .hamburger-inner::after {
+  .hamburger--collapse-r .hamburger-inner-2 {
     top: -20px;
     transition: top 0.2s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1), opacity 0.1s linear; }
-  .hamburger--collapse-r .hamburger-inner::before {
+  .hamburger--collapse-r .hamburger-inner-1 {
     transition: top 0.12s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1), transform 0.13s cubic-bezier(0.55, 0.055, 0.675, 0.19); }
 
 .hamburger--collapse-r.is-active .hamburger-inner {
   transform: translate3d(0, -10px, 0) rotate(45deg);
   transition-delay: 0.22s;
   transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1); }
-  .hamburger--collapse-r.is-active .hamburger-inner::after {
+  .hamburger--collapse-r.is-active .hamburger-inner-2 {
     top: 0;
     opacity: 0;
     transition: top 0.2s cubic-bezier(0.33333, 0, 0.66667, 0.33333), opacity 0.1s 0.22s linear; }
-  .hamburger--collapse-r.is-active .hamburger-inner::before {
+  .hamburger--collapse-r.is-active .hamburger-inner-1 {
     top: 0;
     transform: rotate(90deg);
     transition: top 0.1s 0.16s cubic-bezier(0.33333, 0, 0.66667, 0.33333), transform 0.13s 0.25s cubic-bezier(0.215, 0.61, 0.355, 1); }
@@ -317,20 +317,20 @@
   top: 2px;
   transition-duration: 0.275s;
   transition-timing-function: cubic-bezier(0.68, -0.55, 0.265, 1.55); }
-  .hamburger--elastic .hamburger-inner::before {
+  .hamburger--elastic .hamburger-inner-1 {
     top: 10px;
     transition: opacity 0.125s 0.275s ease; }
-  .hamburger--elastic .hamburger-inner::after {
+  .hamburger--elastic .hamburger-inner-2 {
     top: 20px;
     transition: transform 0.275s cubic-bezier(0.68, -0.55, 0.265, 1.55); }
 
 .hamburger--elastic.is-active .hamburger-inner {
   transform: translate3d(0, 10px, 0) rotate(135deg);
   transition-delay: 0.075s; }
-  .hamburger--elastic.is-active .hamburger-inner::before {
+  .hamburger--elastic.is-active .hamburger-inner-1 {
     transition-delay: 0s;
     opacity: 0; }
-  .hamburger--elastic.is-active .hamburger-inner::after {
+  .hamburger--elastic.is-active .hamburger-inner-2 {
     transform: translate3d(0, -20px, 0) rotate(-270deg);
     transition-delay: 0.075s; }
 
@@ -341,20 +341,20 @@
   top: 2px;
   transition-duration: 0.275s;
   transition-timing-function: cubic-bezier(0.68, -0.55, 0.265, 1.55); }
-  .hamburger--elastic-r .hamburger-inner::before {
+  .hamburger--elastic-r .hamburger-inner-1 {
     top: 10px;
     transition: opacity 0.125s 0.275s ease; }
-  .hamburger--elastic-r .hamburger-inner::after {
+  .hamburger--elastic-r .hamburger-inner-2 {
     top: 20px;
     transition: transform 0.275s cubic-bezier(0.68, -0.55, 0.265, 1.55); }
 
 .hamburger--elastic-r.is-active .hamburger-inner {
   transform: translate3d(0, 10px, 0) rotate(-135deg);
   transition-delay: 0.075s; }
-  .hamburger--elastic-r.is-active .hamburger-inner::before {
+  .hamburger--elastic-r.is-active .hamburger-inner-1 {
     transition-delay: 0s;
     opacity: 0; }
-  .hamburger--elastic-r.is-active .hamburger-inner::after {
+  .hamburger--elastic-r.is-active .hamburger-inner-2 {
     transform: translate3d(0, -20px, 0) rotate(270deg);
     transition-delay: 0.075s; }
 
@@ -365,10 +365,10 @@
   overflow: hidden; }
   .hamburger--emphatic .hamburger-inner {
     transition: background-color 0.125s 0.175s ease-in; }
-    .hamburger--emphatic .hamburger-inner::before {
+    .hamburger--emphatic .hamburger-inner-1 {
       left: 0;
       transition: transform 0.125s cubic-bezier(0.6, 0.04, 0.98, 0.335), top 0.05s 0.125s linear, left 0.125s 0.175s ease-in; }
-    .hamburger--emphatic .hamburger-inner::after {
+    .hamburger--emphatic .hamburger-inner-2 {
       top: 10px;
       right: 0;
       transition: transform 0.125s cubic-bezier(0.6, 0.04, 0.98, 0.335), top 0.05s 0.125s linear, right 0.125s 0.175s ease-in; }
@@ -376,12 +376,12 @@
     transition-delay: 0s;
     transition-timing-function: ease-out;
     background-color: transparent; }
-    .hamburger--emphatic.is-active .hamburger-inner::before {
+    .hamburger--emphatic.is-active .hamburger-inner-1 {
       left: -80px;
       top: -80px;
       transform: translate3d(80px, 80px, 0) rotate(45deg);
       transition: left 0.125s ease-out, top 0.05s 0.125s linear, transform 0.125s 0.175s cubic-bezier(0.075, 0.82, 0.165, 1); }
-    .hamburger--emphatic.is-active .hamburger-inner::after {
+    .hamburger--emphatic.is-active .hamburger-inner-2 {
       right: -80px;
       top: -80px;
       transform: translate3d(-80px, 80px, 0) rotate(-45deg);
@@ -394,10 +394,10 @@
   overflow: hidden; }
   .hamburger--emphatic-r .hamburger-inner {
     transition: background-color 0.125s 0.175s ease-in; }
-    .hamburger--emphatic-r .hamburger-inner::before {
+    .hamburger--emphatic-r .hamburger-inner-1 {
       left: 0;
       transition: transform 0.125s cubic-bezier(0.6, 0.04, 0.98, 0.335), top 0.05s 0.125s linear, left 0.125s 0.175s ease-in; }
-    .hamburger--emphatic-r .hamburger-inner::after {
+    .hamburger--emphatic-r .hamburger-inner-2 {
       top: 10px;
       right: 0;
       transition: transform 0.125s cubic-bezier(0.6, 0.04, 0.98, 0.335), top 0.05s 0.125s linear, right 0.125s 0.175s ease-in; }
@@ -405,12 +405,12 @@
     transition-delay: 0s;
     transition-timing-function: ease-out;
     background-color: transparent; }
-    .hamburger--emphatic-r.is-active .hamburger-inner::before {
+    .hamburger--emphatic-r.is-active .hamburger-inner-1 {
       left: -80px;
       top: 80px;
       transform: translate3d(80px, -80px, 0) rotate(-45deg);
       transition: left 0.125s ease-out, top 0.05s 0.125s linear, transform 0.125s 0.175s cubic-bezier(0.075, 0.82, 0.165, 1); }
-    .hamburger--emphatic-r.is-active .hamburger-inner::after {
+    .hamburger--emphatic-r.is-active .hamburger-inner-2 {
       right: -80px;
       top: 80px;
       transform: translate3d(-80px, -80px, 0) rotate(45deg);
@@ -419,17 +419,17 @@
 /*
    * Minus
    */
-.hamburger--minus .hamburger-inner::before, .hamburger--minus .hamburger-inner::after {
+.hamburger--minus .hamburger-inner-1, .hamburger--minus .hamburger-inner-2 {
   transition: bottom 0.08s 0s ease-out, top 0.08s 0s ease-out, opacity 0s linear; }
 
-.hamburger--minus.is-active .hamburger-inner::before, .hamburger--minus.is-active .hamburger-inner::after {
+.hamburger--minus.is-active .hamburger-inner-1, .hamburger--minus.is-active .hamburger-inner-2 {
   opacity: 0;
   transition: bottom 0.08s ease-out, top 0.08s ease-out, opacity 0s 0.08s linear; }
 
-.hamburger--minus.is-active .hamburger-inner::before {
+.hamburger--minus.is-active .hamburger-inner-1 {
   top: 0; }
 
-.hamburger--minus.is-active .hamburger-inner::after {
+.hamburger--minus.is-active .hamburger-inner-2 {
   bottom: 0; }
 
 /*
@@ -437,20 +437,20 @@
    */
 .hamburger--slider .hamburger-inner {
   top: 2px; }
-  .hamburger--slider .hamburger-inner::before {
+  .hamburger--slider .hamburger-inner-1 {
     top: 10px;
     transition-property: transform, opacity;
     transition-timing-function: ease;
     transition-duration: 0.15s; }
-  .hamburger--slider .hamburger-inner::after {
+  .hamburger--slider .hamburger-inner-2 {
     top: 20px; }
 
 .hamburger--slider.is-active .hamburger-inner {
   transform: translate3d(0, 10px, 0) rotate(45deg); }
-  .hamburger--slider.is-active .hamburger-inner::before {
+  .hamburger--slider.is-active .hamburger-inner-1 {
     transform: rotate(-45deg) translate3d(-5.71429px, -6px, 0);
     opacity: 0; }
-  .hamburger--slider.is-active .hamburger-inner::after {
+  .hamburger--slider.is-active .hamburger-inner-2 {
     transform: translate3d(0, -20px, 0) rotate(-90deg); }
 
 /*
@@ -458,20 +458,20 @@
    */
 .hamburger--slider-r .hamburger-inner {
   top: 2px; }
-  .hamburger--slider-r .hamburger-inner::before {
+  .hamburger--slider-r .hamburger-inner-1 {
     top: 10px;
     transition-property: transform, opacity;
     transition-timing-function: ease;
     transition-duration: 0.15s; }
-  .hamburger--slider-r .hamburger-inner::after {
+  .hamburger--slider-r .hamburger-inner-2 {
     top: 20px; }
 
 .hamburger--slider-r.is-active .hamburger-inner {
   transform: translate3d(0, 10px, 0) rotate(-45deg); }
-  .hamburger--slider-r.is-active .hamburger-inner::before {
+  .hamburger--slider-r.is-active .hamburger-inner-1 {
     transform: rotate(45deg) translate3d(5.71429px, -6px, 0);
     opacity: 0; }
-  .hamburger--slider-r.is-active .hamburger-inner::after {
+  .hamburger--slider-r.is-active .hamburger-inner-2 {
     transform: translate3d(0, -20px, 0) rotate(90deg); }
 
 /*
@@ -480,20 +480,20 @@
 .hamburger--spin .hamburger-inner {
   transition-duration: 0.22s;
   transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19); }
-  .hamburger--spin .hamburger-inner::before {
+  .hamburger--spin .hamburger-inner-1 {
     transition: top 0.1s 0.25s ease-in, opacity 0.1s ease-in; }
-  .hamburger--spin .hamburger-inner::after {
+  .hamburger--spin .hamburger-inner-2 {
     transition: bottom 0.1s 0.25s ease-in, transform 0.22s cubic-bezier(0.55, 0.055, 0.675, 0.19); }
 
 .hamburger--spin.is-active .hamburger-inner {
   transform: rotate(225deg);
   transition-delay: 0.12s;
   transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1); }
-  .hamburger--spin.is-active .hamburger-inner::before {
+  .hamburger--spin.is-active .hamburger-inner-1 {
     top: 0;
     opacity: 0;
     transition: top 0.1s ease-out, opacity 0.1s 0.12s ease-out; }
-  .hamburger--spin.is-active .hamburger-inner::after {
+  .hamburger--spin.is-active .hamburger-inner-2 {
     bottom: 0;
     transform: rotate(-90deg);
     transition: bottom 0.1s ease-out, transform 0.22s 0.12s cubic-bezier(0.215, 0.61, 0.355, 1); }
@@ -504,20 +504,20 @@
 .hamburger--spin-r .hamburger-inner {
   transition-duration: 0.22s;
   transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19); }
-  .hamburger--spin-r .hamburger-inner::before {
+  .hamburger--spin-r .hamburger-inner-1 {
     transition: top 0.1s 0.25s ease-in, opacity 0.1s ease-in; }
-  .hamburger--spin-r .hamburger-inner::after {
+  .hamburger--spin-r .hamburger-inner-2 {
     transition: bottom 0.1s 0.25s ease-in, transform 0.22s cubic-bezier(0.55, 0.055, 0.675, 0.19); }
 
 .hamburger--spin-r.is-active .hamburger-inner {
   transform: rotate(-225deg);
   transition-delay: 0.12s;
   transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1); }
-  .hamburger--spin-r.is-active .hamburger-inner::before {
+  .hamburger--spin-r.is-active .hamburger-inner-1 {
     top: 0;
     opacity: 0;
     transition: top 0.1s ease-out, opacity 0.1s 0.12s ease-out; }
-  .hamburger--spin-r.is-active .hamburger-inner::after {
+  .hamburger--spin-r.is-active .hamburger-inner-2 {
     bottom: 0;
     transform: rotate(90deg);
     transition: bottom 0.1s ease-out, transform 0.22s 0.12s cubic-bezier(0.215, 0.61, 0.355, 1); }
@@ -528,21 +528,21 @@
 .hamburger--spring .hamburger-inner {
   top: 2px;
   transition: background-color 0s 0.13s linear; }
-  .hamburger--spring .hamburger-inner::before {
+  .hamburger--spring .hamburger-inner-1 {
     top: 10px;
     transition: top 0.1s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1), transform 0.13s cubic-bezier(0.55, 0.055, 0.675, 0.19); }
-  .hamburger--spring .hamburger-inner::after {
+  .hamburger--spring .hamburger-inner-2 {
     top: 20px;
     transition: top 0.2s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1), transform 0.13s cubic-bezier(0.55, 0.055, 0.675, 0.19); }
 
 .hamburger--spring.is-active .hamburger-inner {
   transition-delay: 0.22s;
   background-color: transparent; }
-  .hamburger--spring.is-active .hamburger-inner::before {
+  .hamburger--spring.is-active .hamburger-inner-1 {
     top: 0;
     transition: top 0.1s 0.15s cubic-bezier(0.33333, 0, 0.66667, 0.33333), transform 0.13s 0.22s cubic-bezier(0.215, 0.61, 0.355, 1);
     transform: translate3d(0, 10px, 0) rotate(45deg); }
-  .hamburger--spring.is-active .hamburger-inner::after {
+  .hamburger--spring.is-active .hamburger-inner-2 {
     top: 0;
     transition: top 0.2s cubic-bezier(0.33333, 0, 0.66667, 0.33333), transform 0.13s 0.22s cubic-bezier(0.215, 0.61, 0.355, 1);
     transform: translate3d(0, 10px, 0) rotate(-45deg); }
@@ -556,21 +556,21 @@
   transition-duration: 0.13s;
   transition-delay: 0s;
   transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19); }
-  .hamburger--spring-r .hamburger-inner::after {
+  .hamburger--spring-r .hamburger-inner-2 {
     top: -20px;
     transition: top 0.2s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1), opacity 0s linear; }
-  .hamburger--spring-r .hamburger-inner::before {
+  .hamburger--spring-r .hamburger-inner-1 {
     transition: top 0.1s 0.2s cubic-bezier(0.33333, 0.66667, 0.66667, 1), transform 0.13s cubic-bezier(0.55, 0.055, 0.675, 0.19); }
 
 .hamburger--spring-r.is-active .hamburger-inner {
   transform: translate3d(0, -10px, 0) rotate(-45deg);
   transition-delay: 0.22s;
   transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1); }
-  .hamburger--spring-r.is-active .hamburger-inner::after {
+  .hamburger--spring-r.is-active .hamburger-inner-2 {
     top: 0;
     opacity: 0;
     transition: top 0.2s cubic-bezier(0.33333, 0, 0.66667, 0.33333), opacity 0s 0.22s linear; }
-  .hamburger--spring-r.is-active .hamburger-inner::before {
+  .hamburger--spring-r.is-active .hamburger-inner-1 {
     top: 0;
     transform: rotate(90deg);
     transition: top 0.1s 0.15s cubic-bezier(0.33333, 0, 0.66667, 0.33333), transform 0.13s 0.22s cubic-bezier(0.215, 0.61, 0.355, 1); }
@@ -580,20 +580,20 @@
    */
 .hamburger--stand .hamburger-inner {
   transition: transform 0.075s 0.15s cubic-bezier(0.55, 0.055, 0.675, 0.19), background-color 0s 0.075s linear; }
-  .hamburger--stand .hamburger-inner::before {
+  .hamburger--stand .hamburger-inner-1 {
     transition: top 0.075s 0.075s ease-in, transform 0.075s 0s cubic-bezier(0.55, 0.055, 0.675, 0.19); }
-  .hamburger--stand .hamburger-inner::after {
+  .hamburger--stand .hamburger-inner-2 {
     transition: bottom 0.075s 0.075s ease-in, transform 0.075s 0s cubic-bezier(0.55, 0.055, 0.675, 0.19); }
 
 .hamburger--stand.is-active .hamburger-inner {
   transform: rotate(90deg);
   background-color: transparent;
   transition: transform 0.075s 0s cubic-bezier(0.215, 0.61, 0.355, 1), background-color 0s 0.15s linear; }
-  .hamburger--stand.is-active .hamburger-inner::before {
+  .hamburger--stand.is-active .hamburger-inner-1 {
     top: 0;
     transform: rotate(-45deg);
     transition: top 0.075s 0.1s ease-out, transform 0.075s 0.15s cubic-bezier(0.215, 0.61, 0.355, 1); }
-  .hamburger--stand.is-active .hamburger-inner::after {
+  .hamburger--stand.is-active .hamburger-inner-2 {
     bottom: 0;
     transform: rotate(45deg);
     transition: bottom 0.075s 0.1s ease-out, transform 0.075s 0.15s cubic-bezier(0.215, 0.61, 0.355, 1); }
@@ -603,20 +603,20 @@
    */
 .hamburger--stand-r .hamburger-inner {
   transition: transform 0.075s 0.15s cubic-bezier(0.55, 0.055, 0.675, 0.19), background-color 0s 0.075s linear; }
-  .hamburger--stand-r .hamburger-inner::before {
+  .hamburger--stand-r .hamburger-inner-1 {
     transition: top 0.075s 0.075s ease-in, transform 0.075s 0s cubic-bezier(0.55, 0.055, 0.675, 0.19); }
-  .hamburger--stand-r .hamburger-inner::after {
+  .hamburger--stand-r .hamburger-inner-2 {
     transition: bottom 0.075s 0.075s ease-in, transform 0.075s 0s cubic-bezier(0.55, 0.055, 0.675, 0.19); }
 
 .hamburger--stand-r.is-active .hamburger-inner {
   transform: rotate(-90deg);
   background-color: transparent;
   transition: transform 0.075s 0s cubic-bezier(0.215, 0.61, 0.355, 1), background-color 0s 0.15s linear; }
-  .hamburger--stand-r.is-active .hamburger-inner::before {
+  .hamburger--stand-r.is-active .hamburger-inner-1 {
     top: 0;
     transform: rotate(-45deg);
     transition: top 0.075s 0.1s ease-out, transform 0.075s 0.15s cubic-bezier(0.215, 0.61, 0.355, 1); }
-  .hamburger--stand-r.is-active .hamburger-inner::after {
+  .hamburger--stand-r.is-active .hamburger-inner-2 {
     bottom: 0;
     transform: rotate(45deg);
     transition: bottom 0.075s 0.1s ease-out, transform 0.075s 0.15s cubic-bezier(0.215, 0.61, 0.355, 1); }
@@ -627,20 +627,20 @@
 .hamburger--squeeze .hamburger-inner {
   transition-duration: 0.075s;
   transition-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19); }
-  .hamburger--squeeze .hamburger-inner::before {
+  .hamburger--squeeze .hamburger-inner-1 {
     transition: top 0.075s 0.12s ease, opacity 0.075s ease; }
-  .hamburger--squeeze .hamburger-inner::after {
+  .hamburger--squeeze .hamburger-inner-2 {
     transition: bottom 0.075s 0.12s ease, transform 0.075s cubic-bezier(0.55, 0.055, 0.675, 0.19); }
 
 .hamburger--squeeze.is-active .hamburger-inner {
   transform: rotate(45deg);
   transition-delay: 0.12s;
   transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1); }
-  .hamburger--squeeze.is-active .hamburger-inner::before {
+  .hamburger--squeeze.is-active .hamburger-inner-1 {
     top: 0;
     opacity: 0;
     transition: top 0.075s ease, opacity 0.075s 0.12s ease; }
-  .hamburger--squeeze.is-active .hamburger-inner::after {
+  .hamburger--squeeze.is-active .hamburger-inner-2 {
     bottom: 0;
     transform: rotate(-90deg);
     transition: bottom 0.075s ease, transform 0.075s 0.12s cubic-bezier(0.215, 0.61, 0.355, 1); }
@@ -651,24 +651,24 @@
 .hamburger--vortex .hamburger-inner {
   transition-duration: 0.2s;
   transition-timing-function: cubic-bezier(0.19, 1, 0.22, 1); }
-  .hamburger--vortex .hamburger-inner::before, .hamburger--vortex .hamburger-inner::after {
+  .hamburger--vortex .hamburger-inner-1, .hamburger--vortex .hamburger-inner-2 {
     transition-duration: 0s;
     transition-delay: 0.1s;
     transition-timing-function: linear; }
-  .hamburger--vortex .hamburger-inner::before {
+  .hamburger--vortex .hamburger-inner-1 {
     transition-property: top, opacity; }
-  .hamburger--vortex .hamburger-inner::after {
+  .hamburger--vortex .hamburger-inner-2 {
     transition-property: bottom, transform; }
 
 .hamburger--vortex.is-active .hamburger-inner {
   transform: rotate(765deg);
   transition-timing-function: cubic-bezier(0.19, 1, 0.22, 1); }
-  .hamburger--vortex.is-active .hamburger-inner::before, .hamburger--vortex.is-active .hamburger-inner::after {
+  .hamburger--vortex.is-active .hamburger-inner-1, .hamburger--vortex.is-active .hamburger-inner-2 {
     transition-delay: 0s; }
-  .hamburger--vortex.is-active .hamburger-inner::before {
+  .hamburger--vortex.is-active .hamburger-inner-1 {
     top: 0;
     opacity: 0; }
-  .hamburger--vortex.is-active .hamburger-inner::after {
+  .hamburger--vortex.is-active .hamburger-inner-2 {
     bottom: 0;
     transform: rotate(90deg); }
 
@@ -678,23 +678,23 @@
 .hamburger--vortex-r .hamburger-inner {
   transition-duration: 0.2s;
   transition-timing-function: cubic-bezier(0.19, 1, 0.22, 1); }
-  .hamburger--vortex-r .hamburger-inner::before, .hamburger--vortex-r .hamburger-inner::after {
+  .hamburger--vortex-r .hamburger-inner-1, .hamburger--vortex-r .hamburger-inner-2 {
     transition-duration: 0s;
     transition-delay: 0.1s;
     transition-timing-function: linear; }
-  .hamburger--vortex-r .hamburger-inner::before {
+  .hamburger--vortex-r .hamburger-inner-1 {
     transition-property: top, opacity; }
-  .hamburger--vortex-r .hamburger-inner::after {
+  .hamburger--vortex-r .hamburger-inner-2 {
     transition-property: bottom, transform; }
 
 .hamburger--vortex-r.is-active .hamburger-inner {
   transform: rotate(-765deg);
   transition-timing-function: cubic-bezier(0.19, 1, 0.22, 1); }
-  .hamburger--vortex-r.is-active .hamburger-inner::before, .hamburger--vortex-r.is-active .hamburger-inner::after {
+  .hamburger--vortex-r.is-active .hamburger-inner-1, .hamburger--vortex-r.is-active .hamburger-inner-2 {
     transition-delay: 0s; }
-  .hamburger--vortex-r.is-active .hamburger-inner::before {
+  .hamburger--vortex-r.is-active .hamburger-inner-1 {
     top: 0;
     opacity: 0; }
-  .hamburger--vortex-r.is-active .hamburger-inner::after {
+  .hamburger--vortex-r.is-active .hamburger-inner-2 {
     bottom: 0;
     transform: rotate(-90deg); }

--- a/css/menu.css
+++ b/css/menu.css
@@ -16,7 +16,6 @@
 }
 
 .fl-viewport-header {
-  widht: 100%;
   height: 44px;
   margin: 0 auto;
   line-height: 43px;

--- a/css/menu.css
+++ b/css/menu.css
@@ -5,13 +5,18 @@
   padding-top: 44px;
 }
 
-.fl-viewport-header {
-  position: fixed;
+[data-fl-widget-instance][data-widget-package="com.fliplet.menu.slide-in"] {
+  position: fixed !important;
   top: 0;
   top: constant(safe-area-inset-top);
   top: env(safe-area-inset-top);
   left: 0;
   right: 0;
+  z-index: 10;
+}
+
+.fl-viewport-header {
+  widht: 100%;
   height: 44px;
   margin: 0 auto;
   line-height: 43px;
@@ -22,7 +27,6 @@
   border-bottom: 1px solid rgba(127, 127, 127, 0.1);
   font-weight: 300;
   width: 100%;
-  z-index: 10;
   text-align: center;
   color: #333;
   font-size: 1em;

--- a/css/menu.css
+++ b/css/menu.css
@@ -5,7 +5,7 @@
   padding-top: 44px;
 }
 
-[data-fl-widget-instance][data-widget-package="com.fliplet.menu.slide-in"] {
+[data-fl-widget-instance][data-type="menu"] {
   position: fixed !important;
   top: 0;
   top: constant(safe-area-inset-top);


### PR DESCRIPTION
- Tweaks to the hamburger icon for better styling
- Some style changes made to allow the orange overlay on top 

<img width="380" alt="Screenshot 2019-06-10 at 11 27 28" src="https://user-images.githubusercontent.com/7046481/59189731-cc33f300-8b72-11e9-9f3f-fbd50ef5127b.png">

If the user clicks on the orange overlay, or the cog wheel icon, the menu settings will open on the right side.
If the user clicks on the brush icon, the appearance settings for the menu will open on the right side.

