### PR TITLE
slide in fixed scroll behavior on iOS devices 1047

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -420,5 +420,7 @@ html.no-history.mode-interact .fl-viewport-header .nav-left {
 }
 
 .has-slide-menu {
-  overflow-y: hidden;
+  overflow: hidden;
+  position: fixed;
+  height: 100vh;
 }

--- a/js/menu.js
+++ b/js/menu.js
@@ -31,15 +31,18 @@ function init() {
     });
   }
 
+  // Add wrapper block for prevent background scrolling
+  $('body').wrapInner('<div class="scroll-wrapper"></div>');
+
   $('.fl-menu-overlay').click(function() {
     $(this).closest('.fl-menu').removeClass('active');
     $('.fl-viewport-header .hamburger').removeClass('is-active');
-    $('body, body .container-fluid').removeClass('has-slide-menu');
+    $('.scroll-wrapper').removeClass('has-slide-menu');
   });
 
   $('.fl-menu .fl-close-menu').on('click', function() {
     $(this).parents('.fl-menu').removeClass('active');
-    $('body, body .container-fluid').removeClass('has-slide-menu');
+    $('.scroll-wrapper').removeClass('has-slide-menu');
   });
 
   $('[open-about-overlay]').on('click', function() {
@@ -51,6 +54,6 @@ function init() {
   $('[data-fl-toggle-menu]').click(function (event) {
     event.preventDefault();
     $('.fl-viewport-header .hamburger').toggleClass('is-active');
-    $('body, body .container-fluid').toggleClass('has-slide-menu');
+    $('.scroll-wrapper').toggleClass('has-slide-menu');
   });
 }

--- a/js/menu.js
+++ b/js/menu.js
@@ -34,12 +34,12 @@ function init() {
   $('.fl-menu-overlay').click(function() {
     $(this).closest('.fl-menu').removeClass('active');
     $('.fl-viewport-header .hamburger').removeClass('is-active');
-    $('body').removeClass('has-slide-menu');
+    $('body, body .container-fluid').removeClass('has-slide-menu');
   });
 
   $('.fl-menu .fl-close-menu').on('click', function() {
     $(this).parents('.fl-menu').removeClass('active');
-    $('body').removeClass('has-slide-menu');
+    $('body, body .container-fluid').removeClass('has-slide-menu');
   });
 
   $('[open-about-overlay]').on('click', function() {
@@ -51,6 +51,6 @@ function init() {
   $('[data-fl-toggle-menu]').click(function (event) {
     event.preventDefault();
     $('.fl-viewport-header .hamburger').toggleClass('is-active');
-    $('body').toggleClass('has-slide-menu');
+    $('body, body .container-fluid').toggleClass('has-slide-menu');
   });
 }


### PR DESCRIPTION
@squallstar @tonytlwu 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/1047
## Description
Added additional css rules to fixed scroll on iOS devices because mobile safari browser does not support overflow: hidden when set it to the body tag.  Also tested it on web and both platform iOS and android.
## Backward compatibility
This change is fully backward compatible.