### PR TITLE
[Feature] Menu slide-in accessibility

### DIFF
--- a/build.html
+++ b/build.html
@@ -2,41 +2,41 @@
 <div class="fl-viewport-header {{#if location}}fl-viewport-header-left{{/if}}">
   {{#if location}} {{#if canGoBack}}
   <span class="nav-left fl-menu-back" data-fl-navigate-back>
-        <i class="fa fa-angle-left" aria-hidden="true"></i> <span class="btn-label">Back</span>
+    <i class="fa fa-angle-left" aria-hidden="true"></i> <span class="btn-label">Back</span>
   </span>
   {{/if}} {{#if pages}}
-  <span class="nav-right" data-fl-toggle-menu=".fl-menu">
-        <div class="hamburger hamburger--slider">
-          <span class="hamburger-box">
-            <span class="hamburger-inner">
-              <span class="hamburger-inner-1"></span>
-              <span class="hamburger-inner-2"></span>
-            </span>
-          </span>
-        </div>
-      </span> {{/if}}
+  <span class="nav-right" data-fl-toggle-menu=".fl-menu" tabindex="1">
+    <div class="hamburger hamburger--slider">
+      <span class="hamburger-box">
+        <span class="hamburger-inner">
+          <span class="hamburger-inner-1"></span>
+          <span class="hamburger-inner-2"></span>
+        </span>
+      </span>
+    </div>
+  </span> {{/if}}
   <span class="nav-title">
-      <span>{{title}}</span>
+    <span>{{title}}</span>
   </span>
   {{else}} {{#if canGoBack}}
   <span class="nav-left fl-menu-back" data-fl-navigate-back>
-        <i class="fa fa-angle-left" aria-hidden="true"></i> <span class="btn-label">Back</span>
+    <i class="fa fa-angle-left" aria-hidden="true"></i> <span class="btn-label">Back</span>
   </span>
   {{/if}}
   <span class="nav-title">
-      <span>{{title}}</span>
+    <span>{{title}}</span>
   </span>
   {{#if pages}}
-  <span class="nav-right" data-fl-toggle-menu=".fl-menu">
-        <div class="hamburger hamburger--slider">
-          <span class="hamburger-box">
-            <span class="hamburger-inner">
-              <span class="hamburger-inner-1"></span>
-              <span class="hamburger-inner-2"></span>
-            </span>
-          </span>
-        </div>
-      </span> {{/if}} {{/if}}
+  <span class="nav-right" data-fl-toggle-menu=".fl-menu" tabindex="1">
+    <div class="hamburger hamburger--slider">
+      <span class="hamburger-box">
+        <span class="hamburger-inner">
+          <span class="hamburger-inner-1"></span>
+          <span class="hamburger-inner-2"></span>
+        </span>
+      </span>
+    </div>
+  </span> {{/if}} {{/if}}
 </div>
 <!-- END OF HEADER -->
 
@@ -56,7 +56,8 @@
       <div class="fl-list-default">
         <ul class="main-menu">
           {{#each pages as |page pageIndex|}}
-          <li class="linked {{#if page.icon}}with-icon{{/if}}" data-fl-navigate='{{{page.action}}}' data-page-id="{{page.pageId}}">
+          <li class="linked {{#if page.icon}}with-icon{{/if}}" data-fl-navigate='{{{page.action}}}'
+            data-page-id="{{page.pageId}}" tabindex="1">
             {{#if page.icon}}
             <div class="fl-menu-icon">
               <i class="{{page.icon}} fa-fw"></i>

--- a/js/menu.js
+++ b/js/menu.js
@@ -69,9 +69,14 @@ function init() {
     });
   });
 
-  $('[data-fl-toggle-menu]').click(function (event) {
-    event.preventDefault();
-    $('.fl-viewport-header .hamburger').toggleClass('is-active');
-    $('body').toggleClass('has-slide-menu');
+  $('[data-fl-toggle-menu]').on('click keydown', function(event) {
+    if (event.type === 'click' || event.which === 32 || event.which === 13) {
+      $('.fl-viewport-header .hamburger').toggleClass('is-active');
+      $('body').toggleClass('has-slide-menu');
+    
+      if (event.type === 'keydown') {
+        $('body').find('.fl-menu').toggleClass('active');
+      }
+    }
   });
 }

--- a/js/menu.js
+++ b/js/menu.js
@@ -70,13 +70,15 @@ function init() {
   });
 
   $('[data-fl-toggle-menu]').on('click keydown', function(event) {
-    if (event.type === 'click' || event.which === 32 || event.which === 13) {
-      $('.fl-viewport-header .hamburger').toggleClass('is-active');
-      $('body').toggleClass('has-slide-menu');
-    
-      if (event.type === 'keydown') {
-        $('body').find('.fl-menu').toggleClass('active');
-      }
+    if (event.type !== 'click' && event.which !== 32 && event.which !== 13) {
+      return;
+    }
+
+    $('.fl-viewport-header .hamburger').toggleClass('is-active');
+    $('body').toggleClass('has-slide-menu');
+  
+    if (event.type === 'keydown') {
+      $('body').find('.fl-menu').toggleClass('active');
     }
   });
 }


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6420

## Description
Added accessibility to menu slide-in. Tabindex 1 instead of tabindex 0 is required to make menu more important than page content so tab will not jump to content before the menu.

## Screencast
https://streamable.com/86exo6

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko
